### PR TITLE
fix: convert smileUIInstance into a global atom to guarantee safe access

### DIFF
--- a/app/hooks/useCustomer/customerAtom/customerAtom.ts
+++ b/app/hooks/useCustomer/customerAtom/customerAtom.ts
@@ -1,3 +1,4 @@
 import { atom } from "jotai";
 
 export const CustomerAtom = atom<Customer | undefined>();
+export const IsFetchingCustomerAtom = atom<boolean>(false);

--- a/app/hooks/useCustomer/useReloadCustomer.ts
+++ b/app/hooks/useCustomer/useReloadCustomer.ts
@@ -1,9 +1,9 @@
-import { useSetAtom } from "jotai";
-import { useCallback, useState } from "react";
+import { useAtom, useSetAtom } from "jotai";
+import { useCallback } from "react";
 import { ToastTypes } from "~/components/toast";
 import { useSmileUI } from "../useSmileUI";
 import { useSetToastSettings } from "../useToast";
-import { CustomerAtom } from "./customerAtom";
+import { CustomerAtom, IsFetchingCustomerAtom } from "./customerAtom";
 
 export interface UseReloadCustomerReturnValue {
   isFetchingCustomer: boolean;
@@ -11,13 +11,16 @@ export interface UseReloadCustomerReturnValue {
 }
 
 export const useReloadCustomer = (): UseReloadCustomerReturnValue => {
-  const [isFetchingCustomer, setIsFetchingCustomer] = useState(false);
-  const setCustomer = useSetAtom(CustomerAtom);
   const smileUIInstance = useSmileUI();
   const setToastSettings = useSetToastSettings();
+  const setCustomer = useSetAtom(CustomerAtom);
+  const [isFetchingCustomer, setIsFetchingCustomer] = useAtom(
+    IsFetchingCustomerAtom
+  );
 
   const reloadCustomer = useCallback(() => {
     setIsFetchingCustomer(true);
+
     void smileUIInstance?.smile
       ?.fetchCustomer()
       .then((customer) => {
@@ -35,7 +38,7 @@ export const useReloadCustomer = (): UseReloadCustomerReturnValue => {
       .finally(() => {
         setIsFetchingCustomer(false);
       });
-  }, [smileUIInstance, setCustomer, setToastSettings]);
+  }, [smileUIInstance, setCustomer, setToastSettings, setIsFetchingCustomer]);
 
   return {
     isFetchingCustomer,

--- a/app/hooks/usePointsProducts/usePointsProducts.ts
+++ b/app/hooks/usePointsProducts/usePointsProducts.ts
@@ -11,11 +11,11 @@ export const usePointsProducts = (): PointsProduct[] | undefined => {
     if (pointsProducts) return;
 
     if (smileUIInstance) {
-      void globalThis.window.Smile?.fetchAllPointsProducts().then(
-        (allPointsProducts) => {
+      void smileUIInstance.smile
+        ?.fetchAllPointsProducts()
+        .then((allPointsProducts) => {
           setPointsProducts(allPointsProducts);
-        }
-      );
+        });
     }
   }, [smileUIInstance, pointsProducts]);
 

--- a/app/hooks/useSmileUI/smileUIAtom/index.ts
+++ b/app/hooks/useSmileUI/smileUIAtom/index.ts
@@ -1,0 +1,1 @@
+export * from "./smileUIAtom";

--- a/app/hooks/useSmileUI/smileUIAtom/smileUIAtom.ts
+++ b/app/hooks/useSmileUI/smileUIAtom/smileUIAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const SmileUIAtom = atom<SmileUI | undefined>();


### PR DESCRIPTION
I didn't want to overuse jotai atoms, so I was checking for a primitive field of SmileUI to check if it was ready 😢
I though it was a safe approach until I started to have problems with the redeeming feature.

I converted the local SmileUI state into a global atom (did the same with the fetching customer flag to improve the reload experience)